### PR TITLE
Generate package files before publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mardotio/generate-environment",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mardotio/generate-environment",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mardotio/generate-environment",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "mardotio",
   "description": "Verifies specified environment variables are set",
   "license": "MIT",
@@ -9,7 +9,7 @@
   "files": ["lib/**/*"],
   "repository": "https://github.com/mardotio/generate-environment",
   "scripts": {
-    "build": "tsc",
+    "prepare": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
Previous to this commit, the action for publishing the package would not build the package and would publish it empty. Updated the package scripts so that it's build when running `npm publish`.